### PR TITLE
Change Scale to Resize

### DIFF
--- a/face2vid/data/base_dataset.py
+++ b/face2vid/data/base_dataset.py
@@ -36,7 +36,7 @@ def get_transform(opt, params, method=Image.BICUBIC, normalize=True):
     transform_list = []
     if 'resize' in opt.resize_or_crop:
         osize = [opt.loadSize, opt.loadSize]
-        transform_list.append(transforms.Scale(osize, method))   
+        transform_list.append(transforms.Resize(osize, method))   
     elif 'scale_width' in opt.resize_or_crop:
         transform_list.append(transforms.Lambda(lambda img: __scale_width(img, opt.loadSize, method)))
         


### PR DESCRIPTION
`transforms.Scale` has been deprecated in newer versions of PyTorch TorchVision, so might result in error, including in the given Google Colab demo.
Instead, `transforms.Resize` can be used.